### PR TITLE
Starting balance account with decimals

### DIFF
--- a/src/Betsson.OnlineWallets/Services/OnlineWalletService.cs
+++ b/src/Betsson.OnlineWallets/Services/OnlineWalletService.cs
@@ -22,7 +22,7 @@ namespace Betsson.OnlineWallets.Services
             OnlineWalletEntry? onlineWalletEntry = await _onlineWalletRepository.GetLastOnlineWalletEntryAsync();
 
             // Default BalanceBefore to 0 if there are no transactions
-            decimal amount = onlineWalletEntry == default(OnlineWalletEntry) ? 0 : (onlineWalletEntry.BalanceBefore + onlineWalletEntry.Amount);
+            decimal amount = onlineWalletEntry == default(OnlineWalletEntry) ? 0.00m : (onlineWalletEntry.BalanceBefore + onlineWalletEntry.Amount);
 
             Balance currentBalance = new Balance
             {


### PR DESCRIPTION
The service was starting the balance with amout 0 instead of keeping 0.00 showing the decimals. The current version if you start the balance with 0, and after add a amount with double and withdraw it from the balance you will see 0.00 always been returning to the client.